### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Note that `ipfs://bafyaabakaieac/` is a IPFS URL representing an empty directory
 
 You can upload several files to IPFS by using PUT messages with a [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) body.
 
-You can [append](https://developer.mozilla.org/en-US/docs/Web/API/FormData) to a FormData with `formData.append(fieldname, content, 'filename.txt')` where `fieldname` gets ignored (use something like `file`?), the `content` can either be a String, Blob, or some sort of stream.
+You can [append](https://developer.mozilla.org/en-US/docs/Web/API/FormData) to a FormData with `formData.append(fieldname, content, 'filename.txt')` where `fieldname` should be `file`, the `content` can either be a String, Blob, or some sort of stream.
 The `filename` will be the filename inside the IPFS directory that gets created.
 
 The response will contain a `Location` header with the created URL.


### PR DESCRIPTION
Looking at [this code](https://github.com/RangerMauve/js-ipfs-fetch/blob/default/index.js#L799) it seems like the field name must be `'file'` for it to work

```js
if (fieldName !== 'file') continue
```